### PR TITLE
kill it with fire

### DIFF
--- a/codecov.gemspec
+++ b/codecov.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.description        = %q{hosted code coverage}
   s.homepage           = %q{https://github.com/codecov/codecov-ruby}
   s.summary            = %q{hosted code coverage ruby/rails reporter}
-  s.rubyforge_project  = "codecov"
   s.license            = "MIT"
   s.files              = ["lib/codecov.rb"]
   s.test_files         = ["test/test_codecov.rb"]


### PR DESCRIPTION
Fetching https://github.com/simplifi/codecov-ruby
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /Users/patrick/.gem/ruby/2.7.1/bundler/gems/codecov-ruby-e65b6332be3a/codecov.gemspec:12.